### PR TITLE
fix:解决ElRectification自适应的bug

### DIFF
--- a/autofit.js
+++ b/autofit.js
@@ -49,12 +49,12 @@ const autofit = {
         timer = setTimeout(() => {
           keepFit(dw, dh, dom, ignore, limit);
           isElRectification &&
-            elRectification(currelRectification, currelRectificationResponsive,currelRectificationLevel);
+            elRectification(currelRectification, currelRectificationIsKeepRatio,currelRectificationLevel);
         }, delay);
       else {
         keepFit(dw, dh, dom, ignore, limit);
         isElRectification &&
-          elRectification(currelRectification,currelRectificationResponsive, currelRectificationLevel);
+          elRectification(currelRectification,currelRectificationIsKeepRatio, currelRectificationLevel);
       }
     };
     resize && window.addEventListener("resize", resizeListener);

--- a/autofit.js
+++ b/autofit.js
@@ -91,13 +91,9 @@ function elRectification(el, level = 1) {
     return;
   }
   for (let item of currEl) {
-    if (!isElRectification) {
-      item.originalWidth = item.clientWidth;
-      item.originalHeight = item.clientHeight;
-    }
     let rectification = currScale == 1 ? 1 : currScale * level;
-    item.style.width = `${item.originalWidth * rectification}px`;
-    item.style.height = `${item.originalHeight * rectification}px`;
+    item.style.width = `${100 * rectification}%`;
+    item.style.height = `${100 * rectification}%`;
     item.style.transform = `scale(${1 / currScale})`;
     item.style.transformOrigin = `0 0`;
   }

--- a/autofit.js
+++ b/autofit.js
@@ -1,7 +1,7 @@
 let currRenderDom = null;
 let currelRectification = "";
 let currelRectificationLevel = "";
-let currelRectificationResponsive = "";
+let currelRectificationIsKeepRatio = "";
 let resizeListener = null;
 let timer = null;
 let currScale = 1;
@@ -79,14 +79,14 @@ const autofit = {
     this.isAutofitRunnig && console.log(`autofit.js is off`);
   },
 };
-function elRectification(el,isResponsive = true, level = 1) {
+function elRectification(el,isKeepRatio = true, level = 1) {
   if (!autofit.isAutofitRunnig) {
     console.error("autofit.js：autofit has not been initialized yet");
   }
   !el && console.error(`autofit.js：bad selector: ${el}`);
   currelRectification = el;
   currelRectificationLevel = level;
-  currelRectificationResponsive = isResponsive;
+  currelRectificationIsKeepRatio = isKeepRatio;
   const currEl = document.querySelectorAll(el);
   if (currEl.length == 0) {
     console.error("autofit.js：elRectification found no element");
@@ -98,12 +98,12 @@ function elRectification(el,isResponsive = true, level = 1) {
       item.originalWidth = item.clientWidth;
       item.originalHeight = item.clientHeight;
     }
-    if (isResponsive) {
+    if (isKeepRatio) {
+      item.style.width = `${item.originalWidth * rectification}px`;
+			item.style.height = `${item.originalHeight * rectification}px`;
+		} else {
 			item.style.width = `${100 * rectification}%`;
 			item.style.height = `${100 * rectification}%`;
-		} else {
-			item.style.width = `${item.originalWidth * rectification}px`;
-			item.style.height = `${item.originalHeight * rectification}px`;
 		}
     item.style.transform = `scale(${1 / currScale})`;
     item.style.transformOrigin = `0 0`;

--- a/autofit.js
+++ b/autofit.js
@@ -1,6 +1,7 @@
 let currRenderDom = null;
 let currelRectification = "";
 let currelRectificationLevel = "";
+let currelRectificationResponsive = "";
 let resizeListener = null;
 let timer = null;
 let currScale = 1;
@@ -48,12 +49,12 @@ const autofit = {
         timer = setTimeout(() => {
           keepFit(dw, dh, dom, ignore, limit);
           isElRectification &&
-            elRectification(currelRectification, currelRectificationLevel);
+            elRectification(currelRectification, currelRectificationResponsive,currelRectificationLevel);
         }, delay);
       else {
         keepFit(dw, dh, dom, ignore, limit);
         isElRectification &&
-          elRectification(currelRectification, currelRectificationLevel);
+          elRectification(currelRectification,currelRectificationResponsive, currelRectificationLevel);
       }
     };
     resize && window.addEventListener("resize", resizeListener);
@@ -78,13 +79,14 @@ const autofit = {
     this.isAutofitRunnig && console.log(`autofit.js is off`);
   },
 };
-function elRectification(el, level = 1) {
+function elRectification(el,isResponsive = true, level = 1) {
   if (!autofit.isAutofitRunnig) {
     console.error("autofit.js：autofit has not been initialized yet");
   }
   !el && console.error(`autofit.js：bad selector: ${el}`);
   currelRectification = el;
   currelRectificationLevel = level;
+  currelRectificationResponsive = isResponsive;
   const currEl = document.querySelectorAll(el);
   if (currEl.length == 0) {
     console.error("autofit.js：elRectification found no element");
@@ -92,8 +94,17 @@ function elRectification(el, level = 1) {
   }
   for (let item of currEl) {
     let rectification = currScale == 1 ? 1 : currScale * level;
-    item.style.width = `${100 * rectification}%`;
-    item.style.height = `${100 * rectification}%`;
+    if (!isElRectification) {
+      item.originalWidth = item.clientWidth;
+      item.originalHeight = item.clientHeight;
+    }
+    if (isResponsive) {
+			item.style.width = `${100 * rectification}%`;
+			item.style.height = `${100 * rectification}%`;
+		} else {
+			item.style.width = `${item.originalWidth * rectification}px`;
+			item.style.height = `${item.originalHeight * rectification}px`;
+		}
     item.style.transform = `scale(${1 / currScale})`;
     item.style.transformOrigin = `0 0`;
   }

--- a/index.d.ts
+++ b/index.d.ts
@@ -45,7 +45,12 @@ declare interface autofit {
 }
 declare const autofit: autofit;
 
-declare function elRectification(el: string, level?: number): void;
+/**
+ * @param {string} el - 待处理的元素选择器
+ * @param {boolean} isResponsive - 是否启用响应式处理(可选，默认为 true)
+ * @param {number|undefined} level - 缩放等级(可选，默认为 1)，用于手动调整缩放程度
+ */
+declare function elRectification(el: string,isResponsive?:boolean,level?: number): void;
 
 export default autofit;
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -47,10 +47,10 @@ declare const autofit: autofit;
 
 /**
  * @param {string} el - 待处理的元素选择器
- * @param {boolean} isResponsive - 是否启用响应式处理(可选，默认为 true)
- * @param {number|undefined} level - 缩放等级(可选，默认为 1)，用于手动调整缩放程度
+ * @param {boolean} isKeepRatio - 是否保持纵横比（可选，默认为true，false时将充满父元素）
+ * @param {number|undefined} level - 缩放等级，用于手动调整缩放程度(可选，默认为 1)
  */
-declare function elRectification(el: string,isResponsive?:boolean,level?: number): void;
+declare function elRectification(el: string,isKeepRatio?:boolean,level?: number): void;
 
 export default autofit;
 


### PR DESCRIPTION
- 背景
在公司的cesium项目中使用到这个插件，为了解决热点偏移继而使用了ElRectification。有一个问题是在全屏的时候，原来进行布局的cesium会莫名奇妙的少掉一些部分。
- 问题排查
排查后ElRectification会保持元素本来的比例，但是这个地方并不应该保持他的比例，因为他是嵌套在一个大盒子里面的，这个时候如果你要保持他的比例就会发现由于比例不同，附近的盒子会受到这个ElRectification元素的挤压。
![bug复盘 00_00_00-00_00_30~1](https://github.com/LarryZhu-dev/autofit.js/assets/59329360/b56f5f96-40e6-4dd9-950b-7c74a931e45b)
下面是我写的一个codepen（问题复现）
https://codepen.io/yilaikesi/pen/bGzXWeo
- 解决方案
将计算ElRectification 改成用 百分比来乘 rectification 这个变量可以解决这个问题。这是最后解决的效果，https://codepen.io/yilaikesi/pen/dyaxWOY