### PR TITLE
feat: :sparkles: support attribute selector to fix popper.js element position

### DIFF
--- a/dev/index.html
+++ b/dev/index.html
@@ -41,14 +41,50 @@
       background: #e5e510;
     }
   </style>
+  <link rel="stylesheet" href="//unpkg.com/element-plus/dist/index.css" />
+  <script src="//unpkg.com/vue@3"></script>
+  <script src="//unpkg.com/element-plus"></script>
 </head>
 
 <body style="padding: 0;margin: 0;">
-  <div class="main">
-    <div class="left">left</div>
+  <div id="app" class="main">
+    <div class="left">
+      <el-dropdown >
+        <el-button type="primary" style=" transition-delay: 9999s;">
+          Dropdown List
+        </el-button>
+        <template #dropdown>
+          <el-dropdown-menu>
+            <el-dropdown-item>Action 1</el-dropdown-item>
+            <el-dropdown-item>Action 2</el-dropdown-item>
+            <el-dropdown-item>Action 3</el-dropdown-item>
+            <el-dropdown-item disabled>Action 4</el-dropdown-item>
+            <el-dropdown-item divided>Action 5</el-dropdown-item>
+          </el-dropdown-menu>
+        </template>
+      </el-dropdown>
+    </div>
     <div class="center">center</div>
     <div class="right">right</div>
     <script src="/index.ts" type="module"></script>
+    <script type="module">
+      const  { ElButton,ElMessage, ElMessageBox } = ElementPlus
+      const { createApp } = Vue;
+      const App = {
+        data() {
+          return {
+            message: "Hello Element Plus",
+          };
+        },
+        components: { ElButton,ElMessage, ElMessageBox  },
+        methods: {
+          
+        }
+      };
+      const app = createApp(App);
+      app.use(ElementPlus);
+      app.mount("#app");
+    </script>
   </div>
 </body>
 

--- a/dev/index.ts
+++ b/dev/index.ts
@@ -1,7 +1,8 @@
 import autofit from '../src/index';
 
 autofit.init({
-  el: 'body',
-  cssMode: 'zoom',
-  allowScoll: true,
+  // el: 'body',
+  // cssMode: 'zoom',
+  // allowScoll: true,
+  ignore:['div[id*="el-popper-container"]']
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -222,10 +222,15 @@ function keepFit(
     const realFontSize = realScale != currScale ? item.fontSize : "autofit";
     const realWidth = realScale != currScale ? item.width : "autofit";
     const realHeight = realScale != currScale ? item.height : "autofit";
-    const regex = new RegExp(`${itemEl}(\x20|{)`, "gm");
-    const isIgnored = regex.test(ignoreStyleDOM.innerHTML);
-    if (isIgnored) {
-      continue;
+    const attrSelectorRegExp = /[a-zA-Z0-9]\[.*=.*\]/g; 
+    const isAttrSelector = attrSelectorRegExp.test(itemEl);
+    if(isAttrSelector){}
+    else{
+      const regex = new RegExp(`${itemEl}(\x20|{)`, "gm");
+      const isIgnored = regex.test(ignoreStyleDOM.innerHTML);
+      if (isIgnored) {
+        continue;
+      }
     }
     ignoreStyleDOM.innerHTML += `\n${itemEl} { 
       transform: scale(${realScale})!important;


### PR DESCRIPTION
for some element which position decide by popper.js , such as dropdown  menu in antd and element-plus . 
We can enhance  the  ` ignore`'s CSS selector to solve position deviation question.
